### PR TITLE
Update readme to reference proper image

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ by the host system and accessible by the `mop` user/group.
 The Modulus base image is used like any other image:
 
 ```
-FROM: onmodulus/docker-base
+FROM: onmodulus/baseimage
 
 # Customizations
 


### PR DESCRIPTION
Make update in the readme to reference the correct
docker image for others to pull. Docker image
name has been updated and this will now reflect
the name change
